### PR TITLE
Add CoAP header parser

### DIFF
--- a/src/fastrpc/coap/protocol.nim
+++ b/src/fastrpc/coap/protocol.nim
@@ -1,0 +1,39 @@
+
+type
+  CoapType* = enum
+    Confirmable = 0
+    NonConfirmable = 1
+    Acknowledgement = 2
+    Reset = 3
+
+  CoapHeader* = object
+    version*: uint8
+    msgType*: CoapType
+    tokenLength*: uint8
+    code*: uint8
+    messageId*: uint16
+    token*: seq[byte]
+
+proc parseCoapHeader*(data: openArray[byte]): CoapHeader =
+  ## Parses the CoAP header and token from ``data``.
+  ## Raises ``ValueError`` when ``data`` is too short or the version is wrong.
+  if data.len < 4:
+    raise newException(ValueError, "data too short for CoAP header")
+  let first = data[0]
+  result.version = (first shr 6) and 0b11
+  if result.version != 1:
+    raise newException(ValueError, "unsupported CoAP version: " &
+        $result.version)
+  result.msgType = CoapType((first shr 4) and 0b11)
+  result.tokenLength = first and 0b1111
+  result.code = data[1]
+  result.messageId = (uint16(data[2]) shl 8) or uint16(data[3])
+  if result.tokenLength > 0:
+    if result.tokenLength > 8:
+      raise newException(ValueError,
+          "invalid token length: " & $result.tokenLength)
+    if data.len < 4 + int(result.tokenLength):
+      raise newException(ValueError, "data too short for token")
+    result.token = @data[4 ..< 4 + int(result.tokenLength)]
+  else:
+    result.token = @[]

--- a/src/fastrpc/coap/protocol.nim
+++ b/src/fastrpc/coap/protocol.nim
@@ -14,6 +14,10 @@ type
     messageId*: uint16
     token*: seq[byte]
 
+  CoapOption* = object
+    number*: uint16
+    value*: seq[byte]
+
 proc parseCoapHeader*(data: openArray[byte]): CoapHeader =
   ## Parses the CoAP header and token from ``data``.
   ## Raises ``ValueError`` when ``data`` is too short or the version is wrong.
@@ -37,3 +41,53 @@ proc parseCoapHeader*(data: openArray[byte]): CoapHeader =
     result.token = @data[4 ..< 4 + int(result.tokenLength)]
   else:
     result.token = @[]
+
+proc parseCoapOptions*(data: openArray[byte]): (seq[CoapOption], seq[byte]) =
+  ## Parses the sequence of CoAP options from ``data``.
+  ## Returns the parsed options and any remaining payload bytes.
+  var i = 0
+  var current = 0
+  var options: seq[CoapOption] = @[]
+  while i < data.len:
+    if data[i] == 0xff'u8:
+      return (options, @data[i + 1 ..< data.len])
+    let deltaNib = int(data[i] shr 4)
+    let lenNib = int(data[i] and 0x0f)
+    inc i
+    if deltaNib == 15 or lenNib == 15:
+      raise newException(ValueError, "invalid option header")
+    var delta = deltaNib
+    case deltaNib
+    of 13:
+      if i >= data.len:
+        raise newException(ValueError, "data too short for option delta")
+      delta = 13 + int(data[i])
+      inc i
+    of 14:
+      if i + 1 >= data.len:
+        raise newException(ValueError, "data too short for option delta")
+      delta = 269 + (int(data[i]) shl 8) + int(data[i + 1])
+      i += 2
+    else:
+      discard
+    var length = lenNib
+    case lenNib
+    of 13:
+      if i >= data.len:
+        raise newException(ValueError, "data too short for option length")
+      length = 13 + int(data[i])
+      inc i
+    of 14:
+      if i + 1 >= data.len:
+        raise newException(ValueError, "data too short for option length")
+      length = 269 + (int(data[i]) shl 8) + int(data[i + 1])
+      i += 2
+    else:
+      discard
+    if i + length > data.len:
+      raise newException(ValueError, "data too short for option value")
+    current += delta
+    let value = @data[i ..< i + length]
+    i += length
+    options.add CoapOption(number: uint16(current), value: value)
+  (options, @[])

--- a/tests/t_coap_header.nim
+++ b/tests/t_coap_header.nim
@@ -25,3 +25,26 @@ suite "CoAP header parsing":
     ]
     expect ValueError:
       discard parseCoapHeader(data)
+
+  test "parse options sequence":
+    let data = [
+      0x41'u8,                                      # Ver=1, Type=0 (Confirmable), TKL=1
+      0x01'u8,                                      # Code 0.01 (GET)
+      0x12'u8, 0x34'u8,                             # Message ID 0x1234
+      0x0a'u8,                                      # Token
+      0xb4'u8,                                      # Delta=11, Len=4
+      0x74'u8, 0x65'u8, 0x6d'u8, 0x70'u8,           # "temp"
+      0xd1'u8,                                      # Delta=13, Len=1
+      0x03'u8,                                      # Extended delta value 3 (option number 27)
+      0x00'u8,                                      # Value
+      0xff'u8,                                      # Payload marker
+      0x50'u8, 0x41'u8, 0x59'u8                     # Payload "PAY"
+    ]
+    let h = parseCoapHeader(data)
+    let start = 4 + int(h.tokenLength)
+    let (options, payload) = parseCoapOptions(data[start .. ^1])
+    check options.len == 2
+    check options[0].number == 11 and options[0].value == @[0x74'u8, 0x65'u8,
+        0x6d'u8, 0x70'u8]
+    check options[1].number == 27 and options[1].value == @[0x00'u8]
+    check payload == @[0x50'u8, 0x41'u8, 0x59'u8]

--- a/tests/t_coap_header.nim
+++ b/tests/t_coap_header.nim
@@ -1,0 +1,27 @@
+import std/unittest
+
+import fastrpc/coap/protocol
+
+suite "CoAP header parsing":
+  test "parse simple header":
+    let data = [
+      0x41'u8,          # Ver=1, Type=0 (Confirmable), TKL=1
+      0x01'u8,          # Code 0.01 (GET)
+      0x00'u8, 0x10'u8, # Message ID 16
+      0xff'u8           # Token
+    ]
+    let h = parseCoapHeader(data)
+    check h.version == 1
+    check h.msgType == Confirmable
+    check h.tokenLength == 1
+    check h.code == 1
+    check h.messageId == 16
+    check h.token.len == 1 and h.token[0] == 0xff'u8
+  test "reject invalid token length":
+    let data = [
+      0x4f'u8, # Ver=1, Type=0, TKL=15 (invalid)
+      0x01'u8,
+      0x00'u8, 0x10'u8
+    ]
+    expect ValueError:
+      discard parseCoapHeader(data)


### PR DESCRIPTION
## Summary
- add CoAP protocol header parser with token length validation
- move CoAP protocol module into `coap/` directory and update test import

## Testing
- `nim test` *(fails: cannot open file: threading/channels)*
- `nim c -r tests/t_coap_header.nim`


------
https://chatgpt.com/codex/tasks/task_b_68c56064db648332a32a09d7f6e39cb6